### PR TITLE
[FIX] l10n_mx_hr_payroll: fix ansi txt files

### DIFF
--- a/l10n_mx_hr_payroll/models/hr_payroll_idse_reports.py
+++ b/l10n_mx_hr_payroll/models/hr_payroll_idse_reports.py
@@ -244,7 +244,7 @@ class HrPayrollIDSEReports(models.Model):
                 data_end[6] = "9"
 
                 lines += "".join(str(d) for d in data_end)
-                self.txt_file = base64.b64encode(lines.encode())
+                self.txt_file = base64.b64encode(lines.encode("cp1252"))
                 return {
                     "type": "ir.actions.act_url",
                     "url": "/web/content/hr.payroll.idse.reports/%s/txt_file/%s?download=true"
@@ -287,7 +287,7 @@ class HrPayrollIDSEReports(models.Model):
                 data_end[6] = "9"
 
                 lines += "".join(str(d) for d in data_end)
-                self.txt_file = base64.b64encode(lines.encode())
+                self.txt_file = base64.b64encode(lines.encode("cp1252"))
                 return {
                     "type": "ir.actions.act_url",
                     "url": "/web/content/hr.payroll.idse.reports/%s/txt_file/%s?download=true"
@@ -341,7 +341,7 @@ class HrPayrollIDSEReports(models.Model):
                 data_end[6] = "9"
 
                 lines += "".join(str(d) for d in data_end)
-                self.txt_file = base64.b64encode(lines.encode())
+                self.txt_file = base64.b64encode(lines.encode("cp1252"))
                 return {
                     "type": "ir.actions.act_url",
                     "url": "/web/content/hr.payroll.idse.reports/%s/txt_file/%s?download=true"

--- a/l10n_mx_hr_payroll/models/hr_payroll_sua_reports.py
+++ b/l10n_mx_hr_payroll/models/hr_payroll_sua_reports.py
@@ -314,7 +314,7 @@ class HrPayrollSUAReports(models.Model):
 
                     lines += "".join(str(d) for d in data) + "\n"
 
-                self.txt_file = base64.b64encode(lines.encode())
+                self.txt_file = base64.b64encode(lines.encode("cp1252"))
                 return {
                     "type": "ir.actions.act_url",
                     "url": "/web/content/hr.payroll.sua.reports/"
@@ -339,7 +339,7 @@ class HrPayrollSUAReports(models.Model):
 
                         lines += "".join(str(d) for d in data) + "\n"
 
-                    self.txt_file = base64.b64encode(lines.encode())
+                    self.txt_file = base64.b64encode(lines.encode("cp1252"))
                     return {
                         "type": "ir.actions.act_url",
                         "url": "/web/content/hr.payroll.sua.reports/"
@@ -372,7 +372,7 @@ class HrPayrollSUAReports(models.Model):
 
                         lines += "".join(str(d) for d in data) + "\n"
 
-                    self.txt_file = base64.b64encode(lines.encode())
+                    self.txt_file = base64.b64encode(lines.encode("cp1252"))
                     return {
                         "type": "ir.actions.act_url",
                         "url": "/web/content/hr.payroll.sua.reports/"
@@ -401,7 +401,7 @@ class HrPayrollSUAReports(models.Model):
 
                         lines += "".join(str(d) for d in data) + "\n"
 
-                    self.txt_file = base64.b64encode(lines.encode())
+                    self.txt_file = base64.b64encode(lines.encode("cp1252"))
                     return {
                         "type": "ir.actions.act_url",
                         "url": "/web/content/hr.payroll.sua.reports/"
@@ -430,7 +430,7 @@ class HrPayrollSUAReports(models.Model):
 
                         lines += "".join(str(d) for d in data) + "\n"
 
-                    self.txt_file = base64.b64encode(lines.encode())
+                    self.txt_file = base64.b64encode(lines.encode("cp1252"))
                     return {
                         "type": "ir.actions.act_url",
                         "url": "/web/content/hr.payroll.sua.reports/"


### PR DESCRIPTION
Added commands to generate txt files with ANSI encoding, instead of UTF-8